### PR TITLE
Add tap mode to gate expander

### DIFF
--- a/src/TuringGateExpander.cpp
+++ b/src/TuringGateExpander.cpp
@@ -1,5 +1,6 @@
 #include "plugin.hpp"
 #include <cmath>
+#include <vector>
 
 struct TuringGateExpander : Module {
        enum ParamId {
@@ -29,11 +30,9 @@ struct TuringGateExpander : Module {
 
        float value[2] = {};
        uint8_t prevBits = 0;
-       float stepTimer = 0.f;
-       float lastStep = 1.f;
-       float phase = 0.f;
-       int subStep = 0;
-       bool firstStep = true;
+       int gateMode = 0; // 0 = Gate, 1 = Tap
+       float tapTimers[12] = {};
+       const float tapTime = 0.005f;
 
        TuringGateExpander() {
 		config(PARAMS_LEN, INPUTS_LEN, OUTPUTS_LEN, LIGHTS_LEN);
@@ -60,47 +59,105 @@ struct TuringGateExpander : Module {
 		lights[COMBO_LIGHT_4].setBrightness(0.f);
 	}
 
-        void process(const ProcessArgs& args) override {
+       void process(const ProcessArgs& args) override {
                 if (getLeftExpander().module && getLeftExpander().module->model && getLeftExpander().module->model->slug == "TuringMaschine") {
                         float* value = (float*) getLeftExpander().consumerMessage;
                         if (value) {
                                 uint8_t bits = (uint8_t)value[0];
-                                for (int i = 0; i < 8; i++) {
-                                        bool bit = (bits >> i) & 0x1;
-                                        outputs[GATE_OUTPUTS + i].setVoltage(bit ? 10.f : 0.f);
-                                        lights[GATE_LIGHTS + i].setBrightness(bit ? 1.f : 0.f);
-                                }
 
                                 bool g1 = (bits >> 1) & 0x1;
                                 bool g2 = (bits >> 2) & 0x1;
                                 bool g4 = (bits >> 4) & 0x1;
                                 bool g7 = (bits >> 7) & 0x1;
 
-                                // Define new gate outputs as combinations
                                 bool outA = g1 || g2;               // 1 + 2
                                 bool outB = g2 || g4;               // 2 + 4
                                 bool outC = g4 || g7;               // 4 + 7
                                 bool outD = g1 || g2 || g4 || g7;   // 1 + 2 + 4 + 7
 
-                                outputs[GATE_OUTPUT_COMBO_1].setVoltage(outA ? 10.f : 0.f);
-                                outputs[GATE_OUTPUT_COMBO_2].setVoltage(outB ? 10.f : 0.f);
-                                outputs[GATE_OUTPUT_COMBO_3].setVoltage(outC ? 10.f : 0.f);
-                                outputs[GATE_OUTPUT_COMBO_4].setVoltage(outD ? 10.f : 0.f);
+                                if (gateMode == 0) {
+                                        for (int i = 0; i < 8; i++) {
+                                                bool bit = (bits >> i) & 0x1;
+                                                outputs[GATE_OUTPUTS + i].setVoltage(bit ? 10.f : 0.f);
+                                                lights[GATE_LIGHTS + i].setBrightness(bit ? 1.f : 0.f);
+                                        }
+                                        outputs[GATE_OUTPUT_COMBO_1].setVoltage(outA ? 10.f : 0.f);
+                                        outputs[GATE_OUTPUT_COMBO_2].setVoltage(outB ? 10.f : 0.f);
+                                        outputs[GATE_OUTPUT_COMBO_3].setVoltage(outC ? 10.f : 0.f);
+                                        outputs[GATE_OUTPUT_COMBO_4].setVoltage(outD ? 10.f : 0.f);
 
-                                lights[COMBO_LIGHT_1].setBrightness(outA ? 1.f : 0.f);
-                                lights[COMBO_LIGHT_2].setBrightness(outB ? 1.f : 0.f);
-                                lights[COMBO_LIGHT_3].setBrightness(outC ? 1.f : 0.f);
-                                lights[COMBO_LIGHT_4].setBrightness(outD ? 1.f : 0.f);
+                                        lights[COMBO_LIGHT_1].setBrightness(outA ? 1.f : 0.f);
+                                        lights[COMBO_LIGHT_2].setBrightness(outB ? 1.f : 0.f);
+                                        lights[COMBO_LIGHT_3].setBrightness(outC ? 1.f : 0.f);
+                                        lights[COMBO_LIGHT_4].setBrightness(outD ? 1.f : 0.f);
+                                }
+                                else {
+                                        for (int i = 0; i < 8; i++) {
+                                                bool bit = (bits >> i) & 0x1;
+                                                bool prev = (prevBits >> i) & 0x1;
+                                                if (bit != prev)
+                                                        tapTimers[4 + i] = tapTime;
+                                                if (tapTimers[4 + i] > 0.f) {
+                                                        tapTimers[4 + i] -= args.sampleTime;
+                                                        outputs[GATE_OUTPUTS + i].setVoltage(10.f);
+                                                        lights[GATE_LIGHTS + i].setBrightness(1.f);
+                                                }
+                                                else {
+                                                        outputs[GATE_OUTPUTS + i].setVoltage(0.f);
+                                                        lights[GATE_LIGHTS + i].setBrightness(0.f);
+                                                }
+                                        }
+
+                                        bool prev1 = (prevBits >> 1) & 0x1;
+                                        bool prev2 = (prevBits >> 2) & 0x1;
+                                        bool prev4 = (prevBits >> 4) & 0x1;
+                                        bool prev7 = (prevBits >> 7) & 0x1;
+
+                                        bool prevA = prev1 || prev2;
+                                        bool prevB = prev2 || prev4;
+                                        bool prevC = prev4 || prev7;
+                                        bool prevD = prev1 || prev2 || prev4 || prev7;
+
+                                        bool combos[4] = {outA, outB, outC, outD};
+                                        bool prevCombos[4] = {prevA, prevB, prevC, prevD};
+                                        for (int i = 0; i < 4; ++i) {
+                                                if (combos[i] != prevCombos[i])
+                                                        tapTimers[i] = tapTime;
+                                                if (tapTimers[i] > 0.f) {
+                                                        tapTimers[i] -= args.sampleTime;
+                                                        outputs[i].setVoltage(10.f);
+                                                        lights[COMBO_LIGHT_1 + i].setBrightness(1.f);
+                                                }
+                                                else {
+                                                        outputs[i].setVoltage(0.f);
+                                                        lights[COMBO_LIGHT_1 + i].setBrightness(0.f);
+                                                }
+                                        }
+                                }
+
+                                prevBits = bits;
                         }
                         return;
                 }
                 ClearOutputs();
         }
+
+        json_t* dataToJson() override {
+                json_t* root = json_object();
+                json_object_set_new(root, "gateMode", json_integer(gateMode));
+                return root;
+        }
+
+        void dataFromJson(json_t* root) override {
+                json_t* jm = json_object_get(root, "gateMode");
+                if (jm)
+                        gateMode = json_integer_value(jm);
+        }
 };
 
 
 struct TuringGateExpanderWidget : ModuleWidget {
-	TuringGateExpanderWidget(TuringGateExpander* module) {
+        TuringGateExpanderWidget(TuringGateExpander* module) {
 		setModule(module);
 		setPanel(createPanel(asset::plugin(pluginInstance, "res/TuringGateExpander.svg")));
 
@@ -128,8 +185,16 @@ struct TuringGateExpanderWidget : ModuleWidget {
 		addChild(createLightCentered<SmallLight<RedLight>>(mm2px(Vec(15-2.5, 20.0 + 6 * 12.5 - 11)), module, TuringGateExpander::COMBO_LIGHT_3));
 
 		addOutput(createOutputCentered<PJ301MPort>(mm2px(Vec(15.0, 20.0 + 7 * 12.5 - 5)), module, TuringGateExpander::GATE_OUTPUT_COMBO_4));
-		addChild(createLightCentered<SmallLight<RedLight>>(mm2px(Vec(15-2.5, 20.0 + 7 * 12.5 - 11)), module, TuringGateExpander::COMBO_LIGHT_4));
-	}
+                addChild(createLightCentered<SmallLight<RedLight>>(mm2px(Vec(15-2.5, 20.0 + 7 * 12.5 - 11)), module, TuringGateExpander::COMBO_LIGHT_4));
+        }
+
+        void appendContextMenu(Menu* menu) override {
+                TuringGateExpander* module = getModule<TuringGateExpander>();
+                menu->addChild(createIndexPtrSubmenuItem("Gate Mode",
+                        {"Gate", "Tap"},
+                        &module->gateMode
+                ));
+        }
 };
 
 


### PR DESCRIPTION
## Summary
- add gateMode state and tap timer logic
- output short taps when gateMode is set to Tap via the context menu
- store gateMode in module JSON
- expose "Gate Mode" option in expander's right click menu

## Testing
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_684a0282ce3c8329b4d8b4cd7af9840b