### PR TITLE
Fix tape drive 0 bypass

### DIFF
--- a/src/Tape.cpp
+++ b/src/Tape.cpp
@@ -337,7 +337,7 @@ struct Tape : Module {
 
                // Drive knob controls additional tape saturation
                float driveScaled = drive * modeDrive[tapeMode];
-               float satDrive = (driveScaled <= 0.f) ? 1.f : driveScaled;
+               float satDrive = driveScaled;
 
                float saturated = st.saturator.process(driven, satDrive, args.sampleRate);
 

--- a/src/dsp/Saturation.hpp
+++ b/src/dsp/Saturation.hpp
@@ -17,6 +17,8 @@ public:
     float mix = 1.f;
 
     float process(float in, float drive, float sampleRate) {
+        if (drive <= 0.f)
+            return in;
         float norm = rack::math::clamp(in, -1.f, 1.f);
         float upBuf[OS];
         float satBuf[OS];


### PR DESCRIPTION
## Summary
- bypass saturator when drive parameter is zero
- pass drive value directly to saturator

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_684b23ac138083298d07f09ae81af15a