### PR TITLE
Fix drive/input crizzling

### DIFF
--- a/src/Tape.cpp
+++ b/src/Tape.cpp
@@ -274,6 +274,7 @@ struct Tape : Module {
 		LIGHTS_LEN
 	};
 
+       // 2× oversampling is a good CPU compromise
        static const int OS_FACTOR = 2;
 
        struct ChannelState {

--- a/src/dsp/Saturation.hpp
+++ b/src/dsp/Saturation.hpp
@@ -19,7 +19,8 @@ public:
     float process(float in, float drive, float sampleRate) {
         if (drive <= 0.f)
             return in;
-        float norm = rack::math::clamp(in, -1.f, 1.f);
+        // Soft limit the input to avoid digital clipping when input and drive are high
+        float norm = std::tanh(in);
         float upBuf[OS];
         float satBuf[OS];
         upsampler.process(norm, upBuf);


### PR DESCRIPTION
## Summary
- revert oversampling back to 2×
- soften Saturator input instead of clamping

## Testing
- `make clean`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684b249a4edc8329b80267dff73fc3cf