### PR TITLE
Add selectable saturation circuits

### DIFF
--- a/src/Tape.cpp
+++ b/src/Tape.cpp
@@ -17,6 +17,10 @@ static const float modeBump[3] = {1.2f, 1.0f, 0.7f};
 // Amount of "glue" compression for each tape mode
 static const float modeGlue[3] = {1.0f, 0.8f, 0.6f};
 
+// Map drive modes to saturation circuits
+static const int modeSaturatorCircuit[3] = {1, 2, 0};
+static const float modeSaturatorMix[3] = {1.f, 1.f, 0.6f};
+
 // Tape style noise scaling: index 0 = Vintage (no noise floor),
 // index 1 = Classic (moderate noise floor),
 // index 2 = Modern (very quiet noise floor),
@@ -340,7 +344,9 @@ struct Tape : Module {
                float driveScaled = drive * modeDrive[tapeMode];
                float satDrive = driveScaled;
 
-               float saturated = st.saturator.process(driven, satDrive, args.sampleRate);
+               st.saturator.mix = modeSaturatorMix[driveMode];
+               auto circuit = static_cast<dspext::Saturator<OS_FACTOR>::Circuit>(modeSaturatorCircuit[driveMode]);
+               float saturated = st.saturator.process(driven, satDrive, args.sampleRate, circuit);
 
                float warmTail = 0.02f * st.prevSaturated;
                st.prevSaturated = saturated;

--- a/src/dsp/Saturation.hpp
+++ b/src/dsp/Saturation.hpp
@@ -16,7 +16,13 @@ public:
     float env = 0.f;
     float mix = 1.f;
 
-    float process(float in, float drive, float sampleRate) {
+    enum Circuit {
+        EASY,
+        MODERATE,
+        HEAVY
+    };
+
+    float process(float in, float drive, float sampleRate, Circuit circuit) {
         if (drive <= 0.f)
             return in;
         // Soft limit the input to avoid digital clipping when input and drive are high
@@ -38,7 +44,19 @@ public:
             float dynDrive = drive * (1.f + 0.2f * env);
             float cubic = x - (x * x * x) / 3.f;
             float rational = x * (27.f + x * x) / (27.f + 9.f * x * x);
-            float shaped = 0.5f * cubic + 0.5f * rational;
+            float shaped = 0.f;
+            switch (circuit) {
+                default:
+                case HEAVY:
+                    shaped = 0.4f * cubic + 0.6f * rational;
+                    break;
+                case MODERATE:
+                    shaped = 0.5f * x + 0.5f * cubic;
+                    break;
+                case EASY:
+                    shaped = 0.8f * x + 0.2f * cubic;
+                    break;
+            }
             float saturated = shaped * dynDrive;
             // simple soft compression
             float comp = 1.f / (1.f + 0.5f * dynDrive * env);


### PR DESCRIPTION
## Summary
- support multiple saturation circuit modes
- map drive modes to saturation circuits
- use easy circuit with lower mix for Mix mode

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_684b31719080832987610c4e052bed8e