### PR TITLE
Fix GateExpander tap LED visibility

### DIFF
--- a/src/TuringGateExpander.cpp
+++ b/src/TuringGateExpander.cpp
@@ -32,7 +32,8 @@ struct TuringGateExpander : Module {
        uint8_t prevBits = 0;
        int gateMode = 0; // 0 = Gate, 1 = Tap
        float tapTimers[12] = {};
-       const float tapTime = 0.005f;
+       // Duration of LED flash when in Tap mode
+       const float tapTime = 0.05f;
 
        TuringGateExpander() {
 		config(PARAMS_LEN, INPUTS_LEN, OUTPUTS_LEN, LIGHTS_LEN);


### PR DESCRIPTION
## Summary
- increase the tap mode LED blink duration so it's easier to see

## Testing
- `RACK_DIR=../.. make -s` *(fails: No rule to make target `../../plugin.mk`)*

------
https://chatgpt.com/codex/tasks/task_e_684b3beadba48329b95b07956c7eafdf