### PR TITLE
Add new Bass303 controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # AmbushedCat modules for VCV Rack 2
 Heavy hitting with love <3
+
+## Bass303 controls
+
+- **Env Mod** – Filter envelope amount
+- **Decay** – Envelope decay time
+- **Accent Amount** – Accent intensity
+- **Slide Time** – Portamento time
+- **CV In** – Pitch CV input
+- **Gate In** – Trigger input
+- **Accent In** – Optional accent CV

--- a/src/Bass303.cpp
+++ b/src/Bass303.cpp
@@ -51,6 +51,9 @@ struct Bass303 : Module {
         CUTOFF_PARAM,
         RES_PARAM,
         ENV_PARAM,
+        DECAY_PARAM,
+        ACCENT_PARAM,
+        SLIDE_PARAM,
         WAVE_PARAM,
         LEVEL_PARAM,
         PARAMS_LEN
@@ -58,6 +61,7 @@ struct Bass303 : Module {
     enum InputId {
         PITCH_INPUT,
         GATE_INPUT,
+        ACCENT_INPUT,
         INPUTS_LEN
     };
     enum OutputId {
@@ -72,16 +76,21 @@ struct Bass303 : Module {
     float phase = 0.f;
     AcidFilter filter;
     GateEnv env;
+    float slidePitch = 0.f;
 
     Bass303() {
         config(PARAMS_LEN, INPUTS_LEN, OUTPUTS_LEN, LIGHTS_LEN);
         configParam(CUTOFF_PARAM, 0.f, 1.f, 0.5f, "Cutoff");
         configParam(RES_PARAM, 0.f, 1.f, 0.2f, "Resonance");
-        configParam(ENV_PARAM, 0.f, 1.f, 0.5f, "Env Amount");
+        configParam(ENV_PARAM, 0.f, 1.f, 0.5f, "Env Mod");
+        configParam(DECAY_PARAM, 0.f, 1.f, 0.5f, "Decay");
+        configParam(ACCENT_PARAM, 0.f, 1.f, 0.f, "Accent Amount");
+        configParam(SLIDE_PARAM, 0.f, 1.f, 0.f, "Slide Time");
         configParam(WAVE_PARAM, 0.f, 1.f, 0.f, "Waveform");
         configParam(LEVEL_PARAM, 0.f, 1.f, 0.8f, "Level");
-        configInput(PITCH_INPUT, "V/Oct");
-        configInput(GATE_INPUT, "Gate");
+        configInput(PITCH_INPUT, "CV In");
+        configInput(GATE_INPUT, "Gate In");
+        configInput(ACCENT_INPUT, "Accent In");
         configOutput(AUDIO_OUTPUT, "Audio");
     }
 
@@ -89,11 +98,17 @@ struct Bass303 : Module {
         filter.setSampleRate(args.sampleRate);
         float dt = args.sampleTime;
 
+        env.release = rack::math::rescale(params[DECAY_PARAM].getValue(), 0.f, 1.f, 0.05f, 1.f);
+
         bool gate = inputs[GATE_INPUT].getVoltage() >= 1.f;
         float envVal = env.process(gate, dt);
 
-        float pitch = inputs[PITCH_INPUT].getVoltage();
-        float freq = dsp::FREQ_C4 * std::pow(2.f, pitch);
+        float targetPitch = inputs[PITCH_INPUT].getVoltage();
+        float slideTime = rack::math::rescale(params[SLIDE_PARAM].getValue(), 0.f, 1.f, 0.f, 0.5f);
+        float coeff = slideTime > 0.f ? rack::math::clamp(dt / slideTime, 0.f, 1.f) : 1.f;
+        slidePitch += (targetPitch - slidePitch) * coeff;
+
+        float freq = dsp::FREQ_C4 * std::pow(2.f, slidePitch);
         phase += freq * dt;
         if (phase >= 1.f)
             phase -= 1.f;
@@ -102,14 +117,17 @@ struct Bass303 : Module {
         float square = phase < 0.5f ? 1.f : -1.f;
         float wave = (params[WAVE_PARAM].getValue() < 0.5f) ? saw : square;
 
+        float accentGate = inputs[ACCENT_INPUT].isConnected() && inputs[ACCENT_INPUT].getVoltage() >= 1.f ? 1.f : 0.f;
+        float accent = accentGate * params[ACCENT_PARAM].getValue();
+
         float cutoffKnob = params[CUTOFF_PARAM].getValue();
         float cutoff = rack::math::rescale(cutoffKnob, 0.f, 1.f, 80.f, 6000.f);
-        cutoff *= 1.f + envVal * params[ENV_PARAM].getValue() * 2.f;
+        cutoff *= 1.f + envVal * params[ENV_PARAM].getValue() * (1.f + accent) * 2.f;
         float resonance = params[RES_PARAM].getValue();
         filter.setParams(cutoff, resonance);
         float filtered = filter.process(wave);
 
-        float out = filtered * envVal * params[LEVEL_PARAM].getValue();
+        float out = filtered * envVal * (1.f + accent) * params[LEVEL_PARAM].getValue();
         outputs[AUDIO_OUTPUT].setVoltage(5.f * out);
     }
 };
@@ -119,15 +137,19 @@ struct Bass303Widget : ModuleWidget {
         setModule(module);
         setPanel(createPanel(asset::plugin(pluginInstance, "res/TuringMaschine.svg")));
 
-        addParam(createParamCentered<RoundHugeBlackKnob>(mm2px(Vec(15.0, 30.0)), module, Bass303::CUTOFF_PARAM));
-        addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 50.0)), module, Bass303::RES_PARAM));
-        addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 70.0)), module, Bass303::ENV_PARAM));
-        addParam(createParamCentered<CKSS>(mm2px(Vec(15.0, 90.0)), module, Bass303::WAVE_PARAM));
-        addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 110.0)), module, Bass303::LEVEL_PARAM));
+        addParam(createParamCentered<RoundHugeBlackKnob>(mm2px(Vec(15.0, 20.0)), module, Bass303::CUTOFF_PARAM));
+        addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 35.0)), module, Bass303::RES_PARAM));
+        addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 50.0)), module, Bass303::ENV_PARAM));
+        addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 65.0)), module, Bass303::DECAY_PARAM));
+        addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 80.0)), module, Bass303::ACCENT_PARAM));
+        addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 95.0)), module, Bass303::SLIDE_PARAM));
+        addParam(createParamCentered<CKSS>(mm2px(Vec(15.0, 110.0)), module, Bass303::WAVE_PARAM));
+        addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 120.0)), module, Bass303::LEVEL_PARAM));
 
-        addInput(createInputCentered<PJ301MPort>(mm2px(Vec(10.0, 120.0)), module, Bass303::PITCH_INPUT));
-        addInput(createInputCentered<PJ301MPort>(mm2px(Vec(20.0, 120.0)), module, Bass303::GATE_INPUT));
-        addOutput(createOutputCentered<DarkPJ301MPort>(mm2px(Vec(15.0, 130.0)), module, Bass303::AUDIO_OUTPUT));
+        addInput(createInputCentered<PJ301MPort>(mm2px(Vec(10.0, 122.0)), module, Bass303::PITCH_INPUT));
+        addInput(createInputCentered<PJ301MPort>(mm2px(Vec(20.0, 122.0)), module, Bass303::GATE_INPUT));
+        addInput(createInputCentered<PJ301MPort>(mm2px(Vec(10.0, 128.0)), module, Bass303::ACCENT_INPUT));
+        addOutput(createOutputCentered<DarkPJ301MPort>(mm2px(Vec(20.0, 128.0)), module, Bass303::AUDIO_OUTPUT));
     }
 };
 


### PR DESCRIPTION
## Summary
- expand Bass303 with decay, accent, and slide parameters
- expose accent CV input
- document new Bass303 controls

## Testing
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_6854486712b48329b01d5f563052730f