### PR TITLE
Modern diode ladder Bass303

### DIFF
--- a/src/Bass303.cpp
+++ b/src/Bass303.cpp
@@ -1,54 +1,7 @@
 #include "plugin.hpp"
+#include "dsp/DiodeLadder.cpp"
 #include <cmath>
 
-struct AcidFilter {
-    float cutoff = 1000.f;
-    float resonance = 0.1f;
-    float sampleRate = 44100.f;
-    float y1 = 0.f, y2 = 0.f, y3 = 0.f, y4 = 0.f;
-    float oldx = 0.f, oldy1 = 0.f, oldy2 = 0.f, oldy3 = 0.f;
-
-    void setSampleRate(float sr) {
-        sampleRate = sr;
-    }
-
-    void setParams(float fc, float res) {
-        cutoff = fc;
-        resonance = res;
-    }
-
-    float process(float in) {
-        float f = cutoff / sampleRate;
-        f = rack::math::clamp(f, 0.f, 0.99f);
-
-        // coefficients for classic 4-pole ladder approximation
-        float k = 3.6f * f - 1.6f * f * f - 1.f;
-        float p = (k + 1.f) * 0.5f;
-        float scale = std::exp((1.f - p) * 1.386249f);
-        float r = resonance * scale;
-
-        float x = in - r * y4;
-
-        float y1n = x * p + oldx * p - k * y1;
-        float y2n = y1n * p + oldy1 * p - k * y2;
-        float y3n = y2n * p + oldy2 * p - k * y3;
-        float y4n = y3n * p + oldy3 * p - k * y4;
-
-        // Non-linear clipping for acid character
-        y4n -= y4n * y4n * y4n * 0.166667f;
-
-        oldx = x;
-        oldy1 = y1n;
-        oldy2 = y2n;
-        oldy3 = y3n;
-        y1 = y1n;
-        y2 = y2n;
-        y3 = y3n;
-        y4 = y4n;
-
-        return y4n;
-    }
-};
 
 struct GateEnv {
     float attack = 0.001f;
@@ -93,7 +46,7 @@ struct Bass303 : Module {
 
     dsp::SchmittTrigger gateTrigger;
     float phase = 0.f;
-    AcidFilter filter;
+    DiodeLadder filter;
     GateEnv env;
     float slidePitch = 0.f;
 
@@ -134,7 +87,8 @@ struct Bass303 : Module {
 
         float saw = 2.f * phase - 1.f;
         float square = phase < 0.5f ? 1.f : -1.f;
-        float wave = (params[WAVE_PARAM].getValue() < 0.5f) ? saw : square;
+        float mix = params[WAVE_PARAM].getValue();
+        float wave = rack::math::crossfade(saw, square, mix);
 
         float accentGate = inputs[ACCENT_INPUT].isConnected() && inputs[ACCENT_INPUT].getVoltage() >= 1.f ? 1.f : 0.f;
         float accent = accentGate * params[ACCENT_PARAM].getValue();
@@ -143,7 +97,9 @@ struct Bass303 : Module {
         float cutoff = rack::math::rescale(cutoffKnob, 0.f, 1.f, 80.f, 6000.f);
         cutoff *= 1.f + envVal * params[ENV_PARAM].getValue() * (1.f + accent) * 2.f;
         float resonance = params[RES_PARAM].getValue();
-        filter.setParams(cutoff, resonance);
+        filter.setCutoff(cutoff);
+        filter.setResonance(resonance);
+        filter.setDrive(0.5f);
         float filtered = filter.process(wave);
 
         float out = filtered * envVal * (1.f + accent) * params[LEVEL_PARAM].getValue();
@@ -154,7 +110,7 @@ struct Bass303 : Module {
 struct Bass303Widget : ModuleWidget {
     Bass303Widget(Bass303* module) {
         setModule(module);
-        setPanel(createPanel(asset::plugin(pluginInstance, "res/TuringMaschine.svg")));
+        setPanel(createPanel(asset::plugin(pluginInstance, "res/Bass303.svg")));
 
         addParam(createParamCentered<RoundHugeBlackKnob>(mm2px(Vec(15.0, 20.0)), module, Bass303::CUTOFF_PARAM));
         addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 35.0)), module, Bass303::RES_PARAM));
@@ -162,7 +118,7 @@ struct Bass303Widget : ModuleWidget {
         addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 65.0)), module, Bass303::DECAY_PARAM));
         addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 80.0)), module, Bass303::ACCENT_PARAM));
         addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 95.0)), module, Bass303::SLIDE_PARAM));
-        addParam(createParamCentered<CKSS>(mm2px(Vec(15.0, 110.0)), module, Bass303::WAVE_PARAM));
+        addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 110.0)), module, Bass303::WAVE_PARAM));
         addParam(createParamCentered<RoundLargeBlackKnob>(mm2px(Vec(15.0, 120.0)), module, Bass303::LEVEL_PARAM));
 
         addInput(createInputCentered<PJ301MPort>(mm2px(Vec(10.0, 122.0)), module, Bass303::PITCH_INPUT));

--- a/src/dsp/DiodeLadder.cpp
+++ b/src/dsp/DiodeLadder.cpp
@@ -1,12 +1,13 @@
 #pragma once
 #include <cmath>
 
-// Simple diode ladder lowpass filter approximation
+// Diode ladder lowpass filter with simple drive control
 // Provides a resonant 4-pole sound inspired by the TB-303
 struct DiodeLadder {
     float sampleRate = 44100.f;
     float cutoff = 1000.f;
     float resonance = 0.f;
+    float drive = 0.f;
 
     float stage[4] = {};
     float g = 0.f;
@@ -27,6 +28,10 @@ struct DiodeLadder {
         updateCoeffs();
     }
 
+    void setDrive(float d) {
+        drive = d;
+    }
+
     void reset() {
         for (int i = 0; i < 4; ++i) {
             stage[i] = 0.f;
@@ -34,8 +39,9 @@ struct DiodeLadder {
     }
 
     float process(float in) {
+        float input = in * (1.f + drive);
         float feedback = k * stage[3];
-        float x = std::tanh(in - feedback);
+        float x = std::tanh(input - feedback);
         for (int i = 0; i < 4; ++i) {
             stage[i] += g * (x - stage[i]);
             x = std::tanh(stage[i]);


### PR DESCRIPTION
## Summary
- integrate new `DiodeLadder` filter and drive control
- switch Bass303 waveform control to a knob allowing crossfade
- use the Bass303 panel

## Testing
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_685466e3f82083298601d925177935e7