### PR TITLE
Implement dynamic 303 resonance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ Heavy hitting with love <3
 - **Accent In** – Optional accent CV
 
 The Bass303 emulates the classic 3‑pole diode ladder filter of the original TB‑303.
-Its resonance path is softly clipped so it never self‑oscillates, while an internal
+Its resonance path is softly clipped so it never self‑oscillates and now follows the envelope
+and accent for a more authentic response. An internal
 saturator adds a touch of post‑filter distortion for extra squelch.

--- a/src/Bass303.cpp
+++ b/src/Bass303.cpp
@@ -123,7 +123,7 @@ struct Bass303 : Module {
 
         // --- Resonance modulation ---
         float resKnob = params[RES_PARAM].getValue();
-        float resonance = resKnob * (1.f + 0.8f * accent) * shapedEnv;
+        float resonance = resKnob * (1.f + 0.8f * accent);
         resonance = clamp(resonance, 0.f, 1.f);
 
         // --- Drive control ---

--- a/src/dsp/AcidFilter.cpp
+++ b/src/dsp/AcidFilter.cpp
@@ -54,7 +54,8 @@ struct AcidFilter {
         float input = std::tanh(in * drive);
 
         // Diode-style nonlinear feedback
-        float fb = k * stage[3];
+        float dynamicK = k * (1.f + 0.3f * accent + 0.2f * envVal);
+        float fb = dynamicK * stage[3];
         float feedback = (fb >= 0.f) ? std::tanh(fb * 0.9f) : 0.5f * std::tanh(fb * 1.5f);
         // Input minus feedback
         float x = input - feedback;


### PR DESCRIPTION
## Summary
- adjust Bass303 filter resonance calculation
- modulate filter resonance using envelope and accent in `AcidFilter`
- document the more authentic 303 response

## Testing
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6854a18127c083299d5dd120937ab3f2