### PR TITLE
Fix filter usage in Bass303

### DIFF
--- a/src/Bass303.cpp
+++ b/src/Bass303.cpp
@@ -157,13 +157,17 @@ struct Bass303 : Module {
 
         // --- Set filter parameters ---
         filter.setCutoff(cutoff);
+        filter.setResonance(resonance * 100.f);
+        filter.setDrive(drive * 24.f); // map 0-1 range to dB
 
         // --- Pre-filter diode-style saturation ---
         float drivenInput = diodeClip(wave * (2.0f + 2.0f * accent));
 
         // --- Filter processing ---
-        float filtered  = allpass.getSample(drivenInput);
-        filtered = highpass2.getSample(filtered);        
+        float filtered = highpass1.getSample(drivenInput);
+        filtered = filter.getSample(filtered);
+        filtered = allpass.getSample(filtered);
+        filtered = highpass2.getSample(filtered);
         filtered = notch.getSample(filtered);
 
         // --- Envelope-based amplitude control ---


### PR DESCRIPTION
## Summary
- connect TeeBee filter in the signal chain
- set resonance and drive parameters when processing audio

## Testing
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_685539b01c34832990240d180d595217